### PR TITLE
build: publish only when pushing to prod

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,8 +3,6 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
This pull request modifies the GitHub Actions workflow to streamline the deployment process by removing unnecessary triggers.

### Workflow simplification:
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L6-L7): Removed the `pull_request` trigger from the `Deploy to GitHub Pages` workflow, ensuring the workflow only runs on `push` events to the `main` branch.